### PR TITLE
feat: add Docker support for portable containerized runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.11-slim
+
+# Install SUMO (headless)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends sumo \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV SUMO_HOME=/usr/share/sumo
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY *.py .
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+
+# Scenario files (Repaired.sumocfg, *.net.xml, *.rou.xml) are not committed
+# to the repo and must be mounted at runtime — see docker-compose.yml.
+# outputs/ is also expected to be a host-mounted volume.
+RUN mkdir -p outputs
+
+EXPOSE 8765
+
+ENTRYPOINT ["./entrypoint.sh"]
+CMD ["--sumo-binary", "sumo", "--scenario", "advice_guided", "--metrics", "on"]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ python Traci_GPT2.py --run-mode replay --run-id 20260209_012156
 
 **Key flags:** `--messaging on/off`, `--events on/off`, `--web-dashboard on/off`, `--overlays on/off`, `--metrics on/off`
 
+## Docker
+
+```bash
+# Build the image
+docker compose build
+
+# Place scenario files in ./scenario/ (Repaired.sumocfg, *.net.xml, *.rou.xml)
+mkdir -p scenario outputs
+
+# Run (OPENAI_API_KEY is read from your shell environment)
+docker compose run simulation --scenario advice_guided --metrics on
+
+# Override scenario or flags
+docker compose run simulation --scenario no_notice --messaging off --metrics on
+```
+
+Run artifacts are written to `./outputs/` on the host.
+
 ## Parameter Sweep & Calibration
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  simulation:
+    build: .
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - SUMO_HOME=/usr/share/sumo
+      - SUMO_BINARY=sumo
+    volumes:
+      # Scenario files are not in the repo — place Repaired.sumocfg,
+      # Repaired.rou.xml, and any .net.xml files in ./scenario/ on the host.
+      # They are mounted directly into /app/ to match the hardcoded paths in
+      # Traci_GPT2.py.
+      - ./scenario:/app/scenario_src:ro
+      - ./outputs:/app/outputs
+    # Override CMD to pass additional flags, e.g.:
+    #   docker compose run simulation --scenario no_notice --messaging off

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Copy scenario files from the mounted volume into the working directory so
+# they match the hardcoded paths in Traci_GPT2.py (Repaired.sumocfg, etc.).
+if [ -d /app/scenario_src ] && [ "$(ls -A /app/scenario_src 2>/dev/null)" ]; then
+    cp /app/scenario_src/* /app/
+fi
+
+exec python Traci_GPT2.py "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openai
+pydantic
+sumolib
+traci


### PR DESCRIPTION
## Summary

- Adds `Dockerfile` based on `python:3.11-slim` with SUMO installed via apt and `SUMO_HOME` pre-configured
- Adds `docker-compose.yml` that mounts `./scenario/` (for SUMO config files not in the repo) and `./outputs/` (for run artifacts), and injects `OPENAI_API_KEY` from the host environment
- Adds `entrypoint.sh` that copies mounted scenario files into the working directory at startup, matching the hardcoded paths in `Traci_GPT2.py` without any source code changes
- Adds `requirements.txt` pinning the four third-party dependencies (`openai`, `pydantic`, `sumolib`, `traci`)
- Updates `README.md` with a Docker quickstart section

## Test plan

- [ ] `docker compose build` completes without errors
- [ ] Place `Repaired.sumocfg` and network files in `./scenario/`
- [ ] `OPENAI_API_KEY=... docker compose run simulation --scenario advice_guided --metrics on` runs and writes `./outputs/run_metrics.json`

Closes #3